### PR TITLE
implemented generic range on U

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,6 @@ use num::{Float, FromPrimitive, Integer, NumCast, ToPrimitive};
 use std::collections::VecDeque;
 use rayon::prelude::*;
 
-
-#[allow(dead_code)]
 struct IntegerRange<U>
 where
     U: Integer + Copy
@@ -42,7 +40,6 @@ where
     }
 }
 
-#[allow(dead_code)]
 fn range_u<U: Integer + Copy>(start: U, end: U) -> IntegerRange<U> {
     IntegerRange {current: start, end}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,38 @@ use num::{Float, FromPrimitive, Integer, NumCast, ToPrimitive};
 use std::collections::VecDeque;
 use rayon::prelude::*;
 
+
+#[allow(dead_code)]
+struct IntegerRange<U>
+where
+    U: Integer + Copy
+{
+    current: U,
+    end: U,
+}
+
+impl<U> Iterator for IntegerRange<U>
+where 
+    U: Integer + Copy
+{
+    type Item = U;
+
+    fn next(&mut self) -> Option<U> {
+        if self.current < self.end {
+            let next = self.current;
+            self.current = self.current + U::one();
+            Some(next) 
+        } else {
+            None
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn range_u<U: Integer + Copy>(start: U, end: U) -> IntegerRange<U> {
+    IntegerRange {current: start, end}
+}
+
 // Define the Combination struct
 #[derive(Clone)]
 struct Combination<T, U> {
@@ -28,8 +60,96 @@ pub fn count_initial_combinations(scale_min: i32, scale_max: i32) -> i32 {
     (range_size * (range_size + 1)) / 2
 }
 
+// takes in summary statistics, top level function
+pub fn dfs_parallel<T, U>(
+    mean: T,
+    sd: T,
+    n: U,
+    scale_min: U,
+    scale_max: U,
+    rounding_error_mean: T,
+    rounding_error_sd: T,
+) -> Vec<Vec<U>>
+where
+    T: Float + FromPrimitive + Send + Sync, // suggest renaming to F to indicate float type?
+    U: Integer + NumCast + ToPrimitive + Copy + Send + Sync,
+    // how many of these traits will still be necessary by the end? Can we drop ToPrimitive and
+// Numcast? maybe not from here, but maybe from the branch function?
+{
+    // Convert integer `n` to float to enable multiplication with other floats
+    let n_float = T::from(U::to_i32(&n).unwrap()).unwrap();
+    
+    // Target sum calculations
+    let target_sum = mean * n_float;
+    let rounding_error_sum = rounding_error_mean * n_float;
+    
+    let target_sum_upper = target_sum + rounding_error_sum;
+    let target_sum_lower = target_sum - rounding_error_sum;
+    let sd_upper = sd + rounding_error_sd;
+    let sd_lower = sd - rounding_error_sd;
+
+    // Convert to usize for range operations
+    let n_usize = U::to_usize(&n).unwrap();
+    
+    // Precomputing scale sums directly on T types 
+    let scale_min_sum_t: Vec<T> = (0..n_usize)
+        .map(|x| T::from(scale_min).unwrap() * T::from(x).unwrap())
+        .collect();
+    
+    let scale_max_sum_t: Vec<T> = (0..n_usize)
+        .map(|x| T::from(scale_max).unwrap() * T::from(x).unwrap())
+        .collect();
+    
+    let n_minus_1 = n - U::one();
+    let scale_max_plus_1 = scale_max + U::one();
+
+   // instead of generating the initial combinations using concrete types, we're keeping them in U
+    // and T using the iterator for U 
+    let combinations = range_u(scale_min, scale_max_plus_1)
+    .flat_map(|i| {
+        range_u(i, scale_max_plus_1).map(move |j| {
+            let initial_combination = vec![i, j];
+
+            // turn the integer type into the float type
+            // again, might be good for readability to rename T to F
+            let i_float = T::from(i).unwrap();
+            let j_float = T::from(j).unwrap();
+            let sum = i_float + j_float;
+            let current_mean = sum / T::from(2).unwrap();
+
+            let diff_i = i_float - current_mean;
+            let diff_j = j_float - current_mean;
+            let current_m2 = diff_i * diff_i + diff_j * diff_j;
+
+            (initial_combination, sum, current_m2)
+        })
+    })
+    .collect::<Vec<_>>();
+
+    // Process combinations in parallel
+    combinations.par_iter()
+        .flat_map(|(combo, running_sum, running_m2)| {
+            dfs_branch(
+                combo.clone(),
+                *running_sum,
+                *running_m2,
+                n_usize,
+                target_sum_upper,
+                target_sum_lower,
+                sd_upper,
+                sd_lower,
+                &scale_min_sum_t,
+                &scale_max_sum_t,
+                n_minus_1,
+                scale_max_plus_1,
+            )
+        })
+        .collect()
+}
+
 // Collect all valid combinations from a starting point
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn dfs_branch<T, U>(
     start_combination: Vec<U>,
     running_sum_init: T,
@@ -39,9 +159,9 @@ fn dfs_branch<T, U>(
     target_sum_lower: T,
     sd_upper: T,
     sd_lower: T,
-    scale_min_sum: &[U],
-    scale_max_sum: &[U],
-    n_minus_1: U,
+    scale_min_sum_t: &[T],
+    scale_max_sum_t: &[T],
+    _n_minus_1: U,
     scale_max_plus_1: U,
 ) -> Vec<Vec<U>>
 where
@@ -75,32 +195,23 @@ where
         // Get current mean
         let current_mean = current.running_sum / T::from(current_len).unwrap();
 
-        // Get the last value and convert to i32 for range operations
-        let last_value_i32 = U::to_i32(&current.values[current_len - 1]).unwrap();
-        let scale_max_plus_1_i32 = U::to_i32(&scale_max_plus_1).unwrap();
+        // Get the last value        
+        let last_value = current.values[current_len - 1];
 
-        // Use concrete i32 type for the range
-        for next_value_i32 in last_value_i32..scale_max_plus_1_i32 {
-            let next_value = U::from(next_value_i32).unwrap();
-            let next_value_as_t = T::from(next_value_i32).unwrap();
+        for next_value in range_u(last_value, scale_max_plus_1) {
+            let next_value_as_t = T::from(next_value).unwrap();
             let next_sum = current.running_sum + next_value_as_t;
             
             // Safe indexing with bounds check (using usize for indexing)
-            if n_left < scale_min_sum.len() {
-                let scale_min_sum_value = scale_min_sum[n_left]; // Indexing with usize
-                let scale_min_sum_as_t = T::from(U::to_i32(&scale_min_sum_value).unwrap()).unwrap();
-                
-                let minmean = next_sum + scale_min_sum_as_t;
+            if n_left < scale_min_sum_t.len() {
+                let minmean = next_sum + scale_min_sum_t[n_left];
                 if minmean > target_sum_upper {
                     break; // Early termination - better than take_while!
                 }
                 
                 // Safe indexing with bounds check (using usize for indexing)
-                if n_left < scale_max_sum.len() {
-                    let scale_max_sum_value = scale_max_sum[n_left]; // Indexing with usize
-                    let scale_max_sum_as_t = T::from(U::to_i32(&scale_max_sum_value).unwrap()).unwrap();
-                    
-                    let maxmean = next_sum + scale_max_sum_as_t;
+                if n_left < scale_max_sum_t.len() {
+                    let maxmean = next_sum + scale_max_sum_t[n_left];
                     if maxmean < target_sum_lower {
                         continue;
                     }
@@ -110,8 +221,7 @@ where
                     let delta2 = next_value_as_t - next_mean;
                     let next_m2 = current.running_m2 + delta * delta2;
                     
-                    let n_minus_1_float = T::from(n - 1).unwrap();
-                    let min_sd = (next_m2 / n_minus_1_float).sqrt();
+                    let min_sd = (next_m2 / T::from(n - 1).unwrap()).sqrt();
                     if min_sd <= sd_upper {
                         let mut new_values = current.values.clone();
                         new_values.push(next_value);
@@ -125,95 +235,7 @@ where
             }
         }
     }
-
     results
-}
-
-pub fn dfs_parallel<T, U>(
-    mean: T,
-    sd: T,
-    n: U,
-    scale_min: U,
-    scale_max: U,
-    rounding_error_mean: T,
-    rounding_error_sd: T,
-) -> Vec<Vec<U>>
-where
-    T: Float + FromPrimitive + Send + Sync,
-    U: Integer + NumCast + ToPrimitive + Copy + Send + Sync,
-{
-    // Convert integer `n` to float to enable multiplication with other floats
-    let n_float = T::from(U::to_i32(&n).unwrap()).unwrap();
-    
-    // Target sum calculations
-    let target_sum = mean * n_float;
-    let rounding_error_sum = rounding_error_mean * n_float;
-    
-    let target_sum_upper = target_sum + rounding_error_sum;
-    let target_sum_lower = target_sum - rounding_error_sum;
-    let sd_upper = sd + rounding_error_sd;
-    let sd_lower = sd - rounding_error_sd;
-
-    // Convert to concrete types for range operations
-    let n_usize = U::to_usize(&n).unwrap();
-    let scale_min_i32 = U::to_i32(&scale_min).unwrap();
-    let scale_max_i32 = U::to_i32(&scale_max).unwrap();
-    
-    // Precompute scale sums using concrete types first, then convert back to U
-    let scale_min_sum: Vec<U> = (0..n_usize)
-        .map(|x| U::from(scale_min_i32 * (x as i32)).unwrap())
-        .collect();
-    
-    let scale_max_sum: Vec<U> = (0..n_usize)
-        .map(|x| U::from(scale_max_i32 * (x as i32)).unwrap())
-        .collect();
-    
-    let n_minus_1 = n - U::one();
-    let scale_max_plus_1 = scale_max + U::one();
-
-    // Generate initial combinations using concrete types for the ranges
-    let combinations = (scale_min_i32..=scale_max_i32)
-        .flat_map(|i| {
-            (i..=scale_max_i32).map(move |j| {
-                // Convert back to type U for the combination
-                let i_u = U::from(i).unwrap();
-                let j_u = U::from(j).unwrap();
-                let initial_combination = vec![i_u, j_u];
-                
-                // Convert to T for calculations
-                let i_float = T::from(i).unwrap();
-                let j_float = T::from(j).unwrap();
-                let sum = i_float + j_float;
-                let two = T::from(2).unwrap();
-                let current_mean = sum / two;
-                let diff_i = i_float - current_mean;
-                let diff_j = j_float - current_mean;
-                let current_m2 = diff_i * diff_i + diff_j * diff_j;
-                
-                (initial_combination, sum, current_m2)
-            })
-        })
-        .collect::<Vec<_>>();
-
-    // Process combinations in parallel
-    combinations.par_iter()
-        .flat_map(|(combo, running_sum, running_m2)| {
-            dfs_branch(
-                combo.clone(),
-                *running_sum,
-                *running_m2,
-                n_usize,
-                target_sum_upper,
-                target_sum_lower,
-                sd_upper,
-                sd_lower,
-                &scale_min_sum,
-                &scale_max_sum,
-                n_minus_1,
-                scale_max_plus_1,
-            )
-        })
-        .collect()
 }
 
 #[cfg(test)]
@@ -226,3 +248,4 @@ mod tests {
         assert_eq!(count_initial_combinations(1, 4), 10);
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use num::{Float, FromPrimitive, Integer, NumCast, ToPrimitive};
 use std::collections::VecDeque;
 use rayon::prelude::*;
 
+/// Implements range over Rint-friendly generic integer type U
 struct IntegerRange<U>
 where
     U: Integer + Copy
@@ -29,6 +30,7 @@ where
 {
     type Item = U;
 
+    /// Increment over U type integers
     fn next(&mut self) -> Option<U> {
         if self.current < self.end {
             let next = self.current;
@@ -40,6 +42,7 @@ where
     }
 }
 
+/// Creates an iterator over the space of U type integers 
 fn range_u<U: Integer + Copy>(start: U, end: U) -> IntegerRange<U> {
     IntegerRange {current: start, end}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,6 @@ pub fn dfs_parallel<T, U>(
 where
     T: Float + FromPrimitive + Send + Sync, // suggest renaming to F to indicate float type?
     U: Integer + NumCast + ToPrimitive + Copy + Send + Sync,
-    // how many of these traits will still be necessary by the end? Can we drop ToPrimitive and
-// Numcast? maybe not from here, but maybe from the branch function?
 {
     // Convert integer `n` to float to enable multiplication with other floats
     let n_float = T::from(U::to_i32(&n).unwrap()).unwrap();


### PR DESCRIPTION
Implemented an iterator on U types and changed dfs_branch and dfs_parallel code to employ it, directly returning Vec<Vec<U>> while eliminating internal concrete type conversions for performance. 